### PR TITLE
Fix failing test file

### DIFF
--- a/t/test.t
+++ b/t/test.t
@@ -1,5 +1,5 @@
 use Test::More tests => 1;
 
-use Vroom::Vroom;
+use Vroom;
 
-pass 'Vroom::Vroom loaded with no errors.';
+pass 'Vroom loaded with no errors.';


### PR DESCRIPTION
The test file use'd the old name of the module. This caused the test to fail.
