### PR TITLE
Add support for slides in Perl 6 syntax

### DIFF
--- a/ReadMe.pod
+++ b/ReadMe.pod
@@ -187,7 +187,7 @@ characters from the contents of the slide. This can be useful if you need to
 have characters special to Vroom at the beginning of your lines, for example
 if the contents of your slide is unified diff output.
 
-=item C<perl,ruby,python,php,javascript,haskell,actionscript,html,yaml,xml,json,make,shell,diff>
+=item C<perl,perl6,ruby,python,php,javascript,haskell,actionscript,html,yaml,xml,json,make,shell,diff>
 
 Specifies that the slide is one of those syntaxen, and that the appropriate
 file extension will be used, thus causing vim to syntax highlight the slide.

--- a/lib/Vroom.pm
+++ b/lib/Vroom.pm
@@ -166,6 +166,10 @@ sub runSlide {
     if ($slide =~ /\.pl$/) {
         exec "clear; $^X $slide";
     }
+    elsif ($slide =~ /\.p6$/) {
+        my $perl6_binary = $ENV{VROOM_PERL6_PATH} || 'perl6';
+        exec "clear; $perl6_binary $slide";
+    }
 
     $self->trim_slide;
 
@@ -607,8 +611,9 @@ sub formatNumber {
 }
 
 my $types = {
-    # add pl6 and py3
+    # add py3
     perl => 'pl', pl => 'pl', pm => 'pm',
+    perl6 => 'p6', p6 => 'p6', pm6 => 'pm6',
     ruby => 'rb', rb => 'rb',
     python => 'py', py => 'py',
     haskell => 'hs', hs => 'hs',


### PR DESCRIPTION
I recently noticed that Vroom lacked support for slides in Perl 6 syntax, which gets added by the changes in this pull request.