### PR TITLE
Fix incorrect centering for UTF-8 characters

### DIFF
--- a/lib/Vroom.pm
+++ b/lib/Vroom.pm
@@ -465,7 +465,7 @@ sub buildSlides {
                 $slide =~ s/^.{$undent}//gm;
             }
             $slide =~ s{^\ *==\ +(.*?)\ *$}
-                       {' ' x (($self->config->{width} - length($1)) / 2) . $1}gem;
+                       {' ' x (($self->config->{width} - length(decode_utf8($1))) / 2) . $1}gem;
             my $suf = $suffix++;
             $suf = $suf eq 'a'
                 ? ''


### PR DESCRIPTION
Hi, I've found a problem: UTF-8 characters are not correctly centered - seems like this small change fixes it.